### PR TITLE
Full interval unit names, more unit aliases, more units in general

### DIFF
--- a/lib/DateTime/Format/Pg.pm
+++ b/lib/DateTime/Format/Pg.pm
@@ -561,12 +561,16 @@ If given an improperly formatted string, this method may die.
 
 sub parse_duration {
     my ($self, $string) = @_;
-    my ($year, $mon, $day, $sgn, $hour, $min, $sec, $frc, $ago) = $string =~ m{
+    my ($mil, $cent, $dec, $year, $mon, $wk, $day, $sgn, $hour, $min, $sec, $frc, $ago) = $string =~ m{
         \A                                     # Start of string.
         (?:\@\s*)?                             # Optional leading @.
-        (?:([-+]?\d+)\s+years?\s*)?            # years
-        (?:([-+]?\d+)\s+mon(?:th)?s?\s*)?      # months
-        (?:([-+]?\d+)\s+days?\s*)?             # days
+        (?:([-+]?\d+)\s+(?:millennium|millennia|millenniums|mil|mils)\s*)?  # millennia
+        (?:([-+]?\d+)\s+(?:century|centuries|cent|c)\s*)?                   # centuries
+        (?:([-+]?\d+)\s+(?:decade|decades|dec|decs)\s*)?                    # decades
+        (?:([-+]?\d+)\s+(?:year|years|yr|yrs|y)\s*)?                        # years
+        (?:([-+]?\d+)\s+(?:month|months|mon|mons)\s*)?                      # months
+        (?:([-+]?\d+)\s+(?:week|weeks|w)\s*)?                               # weeks
+        (?:([-+]?\d+)\s+(?:day|days|d)\s*)?                                 # days
         (?:                                    # Start h/m/s
           # hours
           (?:([-+])?([0-9]\d|[1-9]\d{2,}(?=:)|\d+(?=\s+hour))(?:\s+hours?)?\s*)?
@@ -589,7 +593,11 @@ sub parse_duration {
 
     # DT::Duration only stores years, days, months, seconds (and
     # nanoseconds)
+    $year += 1000 * $mil if $mil;
+    $year += 100 * $cent if $cent;
+    $year += 10 * $dec   if $dec;
     $mon += 12 * $year if $year;
+    $day +=  7 *   $wk if $wk;
     $min += 60 * $hour if $hour;
 
     # HH:MM:SS.FFFF share a single sign

--- a/t/parse_interval.t
+++ b/t/parse_interval.t
@@ -105,6 +105,46 @@ BEGIN
             hours => -2,
             minutes => -3,
         )],
+
+        [ '1 millennium' => DateTime::Duration->new( years => 1000 )],
+        [ '2 millennia' => DateTime::Duration->new( years => 2000 )],
+        [ '3 millenniums' => DateTime::Duration->new( years => 3000 )],
+        [ '1 mil' => DateTime::Duration->new( years => 1000 )],
+        [ '2 mils' => DateTime::Duration->new( years => 2000 )],
+        
+        [ '1 century' => DateTime::Duration->new( years => 100 )],
+        [ '2 centuries' => DateTime::Duration->new( years => 200 )],
+        [ '1 cent' => DateTime::Duration->new( years => 100 )],
+        [ '2 c' => DateTime::Duration->new( years => 200 )],
+        
+        [ '1 decade' => DateTime::Duration->new( years => 10 )],
+        [ '2 decades' => DateTime::Duration->new( years => 20 )],
+        [ '1 dec' => DateTime::Duration->new( years => 10 )],
+        [ '2 decs' => DateTime::Duration->new( years => 20 )],
+
+        [ '1 year' => DateTime::Duration->new( years => 1 )],
+        [ '2 years' => DateTime::Duration->new( years => 2 )],
+        [ '1 y' => DateTime::Duration->new( years => 1 )],
+        [ '1 yr' => DateTime::Duration->new( years => 1 )],
+        [ '2 yrs' => DateTime::Duration->new( years => 2 )],
+        
+        [ '1 mil 9 c 6 decade 2 yr' => DateTime::Duration->new( years => 1962 )],
+
+        [ '1 month' => DateTime::Duration->new( months => 1 )],
+        [ '2 months' => DateTime::Duration->new( months => 2 )],
+        [ '1 mon' => DateTime::Duration->new( months => 1 )],
+        [ '2 mons' => DateTime::Duration->new( months => 2 )],
+        
+        [ '1 week' => DateTime::Duration->new( weeks => 1 )],
+        [ '2 weeks' => DateTime::Duration->new( weeks => 2 )],
+        [ '1 w' => DateTime::Duration->new( weeks => 1 )],
+        
+        [ '1 day' => DateTime::Duration->new( days => 1 )],
+        [ '2 days' => DateTime::Duration->new( days => 2 )],
+        [ '1 d' => DateTime::Duration->new( days => 1 )],
+        
+        [ '1 mil 2 c 4 decade 8 yr 9 months 18 d ' => DateTime::Duration->new( years => 1248, months => 9, days => 18 )],
+        [ '12 yr 42 w' => DateTime::Duration->new( years => 12, weeks => 42 )],
     );
 
     plan tests => @negative_data + @positive_data + 1;


### PR DESCRIPTION
The words `month`, `months`, `minute`, `minutes`, `second` and `seconds` are valid in PostgreSQL interval. These are now accepted in `parse_duration`.
