### PR TITLE
Fix parse_duration handling

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,10 +1,11 @@
 Revision history for Perl extension DateTime::Format::Pg.
 
 {{$NEXT}}
+    - Fix handling fractional seconds (issue #12)
 
 0.16012 2016-07-19T21:37:31Z
     - Parsing invalid intervals with no amount and units only should have
-      resulted in exceptions, but did not. Reported by Henrik Pauli (ssue #8)
+      resulted in exceptions, but did not. Reported by Henrik Pauli (issue #8)
     - Internal cleanup
 
 0.16011 2015-06-19T13:40:27Z

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ handled unambiguously by PostgreSQL.
 
 If DateStyle is set to 'PostgreSQL', 'SQL', or 'German', PostgreSQL does
 not send numerical time zones for the TIMESTAMPTZ (or TIMESTAMP WITH
-TIME ZONE) type. Unfortunatly, the time zone names used instead can be
+TIME ZONE) type. Unfortunately, the time zone names used instead can be
 ambiguous: For example, 'EST' can mean -0500, +1000, or +1100.
 
 You must set the 'server\_tz' variable to a time zone that is identical to that

--- a/t/gh12.t
+++ b/t/gh12.t
@@ -1,0 +1,20 @@
+use strict;
+use Test::More;
+
+use_ok('DateTime::Format::Pg');
+
+# https://www.postgresql.org/docs/9.5/static/datatype-datetime.html#DATATYPE-INTERVAL-INPUT
+my $offset = '1095 days 13:37:28.36922';
+my $duration;
+eval {
+    $duration = DateTime::Format::Pg->parse_duration($offset);
+};
+my $e = $@;
+if (! ok !$e, "should succeed parsing '$offset' without errors") {
+    diag $e;
+}
+
+is $duration->seconds, 28, "seconds should be '28'";
+is $duration->nanoseconds, 369220, "seconds should be '369220'";
+
+done_testing;


### PR DESCRIPTION
* handle fractional seconds (but only seconds)
* if you want support for fractional [some other unit], please
  send in PRs with new tests

fixes #12